### PR TITLE
arrow support

### DIFF
--- a/src/DataToolkitCommon.jl
+++ b/src/DataToolkitCommon.jl
@@ -31,6 +31,7 @@ include("transformers/storage/git.jl")
 include("transformers/storage/raw.jl")
 include("transformers/storage/web.jl")
 
+include("transformers/saveload/arrow.jl")
 include("transformers/saveload/chain.jl")
 include("transformers/saveload/compression.jl")
 include("transformers/saveload/csv.jl")
@@ -67,6 +68,7 @@ function __init__()
     @addpkg Downloads      "f43a241f-c20a-4ad4-852c-f6b1247861c6"
     @addpkg Git_jll        "f8c6e375-362e-5223-8a59-34ff63f689eb"
     # Loaders
+    @addpkg Arrow          "69666777-d1a9-59fb-9406-91d4454c9d45"
     @addpkg CSV            "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
     @addpkg CodecBzip2     "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
     @addpkg CodecXz        "ba30903b-d9e8-5048-a5ec-d1f5b0d4b47b"
@@ -102,6 +104,7 @@ function __init__()
              (:storage, :passthrough) => PASSTHROUGH_S_DOC,
              (:storage, :raw) => RAW_DOC,
              (:storage, :web) => WEB_DOC,
+             (:loader, :arrow) => ARROW_DOC,
              (:loader, :chain) => CHAIN_DOC,
              (:loader, :gzip) => COMPRESSION_DOC,
              (:loader, :zlib) => COMPRESSION_DOC,

--- a/src/transformers/saveload/arrow.jl
+++ b/src/transformers/saveload/arrow.jl
@@ -44,7 +44,7 @@ Parse and serialize arrow files
 
 The `arrow` driver expects data to be provided via `IO`.
 
-By default this driver supports parsing to three data types:
+By default this driver supports parsing to two data types:
 - `DataFrame`
 - `Arrow.Table`
 

--- a/src/transformers/saveload/arrow.jl
+++ b/src/transformers/saveload/arrow.jl
@@ -1,6 +1,6 @@
 function load(loader::DataLoader{:arrow}, io::IO, sink::Type)
     @import Arrow
-    convert::Bool = @getparam loader."convert"::Bool true
+    convert = @getparam loader."convert"::Bool true
     result = Arrow.Table(io; convert) |>
     if sink == Any || sink == Arrow.Table
         identity
@@ -12,21 +12,20 @@ end
 
 function save(writer::DataWriter{:arrow}, io::IO, tbl)
     @import Arrow
-    compress = @getparam loader."compress"::Union{Symbol, Nothing} nothing
-    alignment = @getparam loader."alignment"::Int 8
-    dictencode = @getparam loader."dictencode"::Bool false
-    dictencodenested = @getparam loader."dictencodenested"::Bool false
-    denseunions = @getparam loader."denseunions"::Bool true
-    largelists = @getparam loader."largelists"::Bool false
-    maxdepth = @getparam loader."maxdepth"::Int 6
-    ntasks = @getparam loader."ntasks"::Int typemax(Int32)
+    compress         = @getparam writer."compress"::Union{Symbol, Nothing} nothing
+    alignment        = @getparam writer."alignment"::Int 8
+    dictencode       = @getparam writer."dictencode"::Bool false
+    dictencodenested = @getparam writer."dictencodenested"::Bool false
+    denseunions      = @getparam writer."denseunions"::Bool true
+    largelists       = @getparam writer."largelists"::Bool false
+    maxdepth         = @getparam writer."maxdepth"::Int 6
+    ntasks           = @getparam writer."ntasks"::Int Int(typemax(Int32))
     Arrow.write(
         io, tbl;
         compress, alignment,
         dictencode, dictencodenested,
         denseunions, largelists,
-        maxdepth, ntasks
-    )
+        maxdepth, ntasks)
 end
 
 supportedtypes(::Type{DataLoader{:arrow}}) =

--- a/src/transformers/saveload/arrow.jl
+++ b/src/transformers/saveload/arrow.jl
@@ -1,7 +1,7 @@
-function load(loader::DataLoader{:arrow}, file::IO, sink::Type)
+function load(loader::DataLoader{:arrow}, io::IO, sink::Type)
     @import Arrow
     convert::Bool = @getparam loader."convert"::Bool true
-    result = Arrow.Table(file; convert) |>
+    result = Arrow.Table(io; convert) |>
     if sink == Any || sink == Arrow.Table
         identity
     elseif QualifiedType(sink) == QualifiedType(:DataFrames, :DataFrame)
@@ -10,7 +10,7 @@ function load(loader::DataLoader{:arrow}, file::IO, sink::Type)
     result
 end
 
-function save(writer::DataWriter{:arrow}, file::IO, tbl)
+function save(writer::DataWriter{:arrow}, io::IO, tbl)
     @import Arrow
     compress::Union{Symbol, Nothing} = @getparam loader."compress"::Union{Symbol, Nothing} nothing
     alignment::Int = @getparam loader."alignment"::Int 8
@@ -21,7 +21,7 @@ function save(writer::DataWriter{:arrow}, file::IO, tbl)
     maxdepth::Int = @getparam loader."maxdepth"::Int 6
     ntasks::Int = @getparam loader."ntasks"::Int typemax(Int32)
     Arrow.write(
-        file, tbl;
+        io, tbl;
         compress, alignment,
         dictencode, dictencodenested,
         denseunions, largelists,

--- a/src/transformers/saveload/arrow.jl
+++ b/src/transformers/saveload/arrow.jl
@@ -30,7 +30,8 @@ function save(writer::DataWriter{:arrow}, io::IO, tbl)
 end
 
 supportedtypes(::Type{DataLoader{:arrow}}) =
-    [QualifiedType(:DataFrames, :DataFrame)]
+    [QualifiedType(:DataFrames, :DataFrame),
+     QualifiedType(:Arrow, :Table)]
 
 create(::Type{DataLoader{:arrow}}, source::String) =
     !isnothing(match(r"\.arrow$"i, source))

--- a/src/transformers/saveload/arrow.jl
+++ b/src/transformers/saveload/arrow.jl
@@ -1,0 +1,65 @@
+function load(loader::DataLoader{:arrow}, file::IO, sink::Type)
+    @import Arrow
+    convert::Bool = @getparam loader."convert"::Bool true
+    result = Arrow.Table(file; convert) |>
+    if sink == Any || sink == Arrow.Table
+        identity
+    elseif QualifiedType(sink) == QualifiedType(:DataFrames, :DataFrame)
+        sink
+    end
+    result
+end
+
+function save(writer::DataWriter{:arrow}, file::IO, tbl)
+    @import Arrow
+    compress::Union{Symbol, Nothing} = @getparam loader."compress"::Union{Symbol, Nothing} nothing
+    alignment::Int = @getparam loader."alignment"::Int 8
+    dictencode::Bool = @getparam loader."dictencode"::Bool false
+    dictencodenested::Bool = @getparam loader."dictencodenested"::Bool false
+    denseunions::Bool = @getparam loader."denseunions"::Bool true
+    largelists::Bool = @getparam loader."largelists"::Bool false
+    maxdepth::Int = @getparam loader."maxdepth"::Int 6
+    ntasks::Int = @getparam loader."ntasks"::Int typemax(Int32)
+    Arrow.write(
+        file, tbl;
+        compress, alignment,
+        dictencode, dictencodenested,
+        denseunions, largelists,
+        maxdepth, ntasks
+    )
+end
+
+supportedtypes(::Type{DataLoader{:arrow}}) =
+    [QualifiedType(:DataFrames, :DataFrame)]
+
+create(::Type{DataLoader{:arrow}}, source::String) =
+    !isnothing(match(r"\.arrow$"i, source))
+
+createpriority(::Type{DataLoader{:arrow}}) = 10
+
+const ARROW_DOC = md"""
+Parse and serialize arrow files
+
+# Input/output
+
+The `arrow` driver expects data to be provided via `IO`.
+
+By default this driver supports parsing to three data types:
+- `DataFrame`
+- `Arrow.Table`
+
+# Required packages
+
++ `Arrow`
+
+# Parameters
+
+- `convert`: controls whether certain arrow primitive types will be converted to more friendly Julia defaults
+
+# Usage examples
+
+```toml
+[[iris.loader]]
+driver = "arrow"
+```
+"""

--- a/src/transformers/saveload/arrow.jl
+++ b/src/transformers/saveload/arrow.jl
@@ -12,14 +12,14 @@ end
 
 function save(writer::DataWriter{:arrow}, io::IO, tbl)
     @import Arrow
-    compress::Union{Symbol, Nothing} = @getparam loader."compress"::Union{Symbol, Nothing} nothing
-    alignment::Int = @getparam loader."alignment"::Int 8
-    dictencode::Bool = @getparam loader."dictencode"::Bool false
-    dictencodenested::Bool = @getparam loader."dictencodenested"::Bool false
-    denseunions::Bool = @getparam loader."denseunions"::Bool true
-    largelists::Bool = @getparam loader."largelists"::Bool false
-    maxdepth::Int = @getparam loader."maxdepth"::Int 6
-    ntasks::Int = @getparam loader."ntasks"::Int typemax(Int32)
+    compress = @getparam loader."compress"::Union{Symbol, Nothing} nothing
+    alignment = @getparam loader."alignment"::Int 8
+    dictencode = @getparam loader."dictencode"::Bool false
+    dictencodenested = @getparam loader."dictencodenested"::Bool false
+    denseunions = @getparam loader."denseunions"::Bool true
+    largelists = @getparam loader."largelists"::Bool false
+    maxdepth = @getparam loader."maxdepth"::Int 6
+    ntasks = @getparam loader."ntasks"::Int typemax(Int32)
     Arrow.write(
         io, tbl;
         compress, alignment,
@@ -56,6 +56,7 @@ By default this driver supports parsing to two data types:
 # Parameters
 
 - `convert`: controls whether certain arrow primitive types will be converted to more friendly Julia defaults
+- The writer mirrors the arguments available in `Arrow.write`.
 
 # Usage examples
 


### PR DESCRIPTION
Hi @tecosaur, I gave the arrow support a shot and here's what I got.

I tested the loader on a simple test dataset and it seems to work for `read(dataset("test"), Any)` and `read(dataset("test"), DataFrame)`. I also implemented the writer but did not test it yet because I didn't know how, maybe you could take a look at that?

Closes tecosaur/DataToolkit.jl#30