### PR TITLE
Change mkpath(...) to mkdir(...)

### DIFF
--- a/src/store/inventory.jl
+++ b/src/store/inventory.jl
@@ -235,7 +235,7 @@ function load_inventory(path::String, create::Bool=true)
             convert(InventoryConfig, Dict{String, Any}()),
             CollectionInfo[], StoreSource[],
             CacheSource[], now())
-        isdir(dirname(path)) || mkpath(dirname(path))
+        isdir(dirname(path)) || mkdir(dirname(path))
         write(inventory)
         inventory
     else


### PR DESCRIPTION
I just changed the `mkpath` to `mkdir`. This change works on my Windows and it also passed all of the tests on my Ubuntu WSL.